### PR TITLE
Remove wrongly named and wrongly placed override for property $datagridValues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+# 3.0.3 - 2018-01-04
+## Removed
+* Removed the wronly named and wronly placed override for `$datagridValues` in the PageAdmin. At this point we don't know yet how to sort the admin-list. Leave this to the default here.
+
+
+# 3.0.1 - # 3.0.2
+## Fixed
+* Various bugfixes concerning the 3.0-release.
+
 # 3.0.0
 ## Breaking Changes
 - Naming admin services of Pages and ContentItems using the fully 

--- a/src/Zicht/Bundle/PageBundle/Admin/PageAdmin.php
+++ b/src/Zicht/Bundle/PageBundle/Admin/PageAdmin.php
@@ -29,14 +29,6 @@ use Zicht\Util\Str;
 class PageAdmin extends Admin
 {
     /**
-     * @var array
-     */
-    protected $dataGridValues = array(
-        '_sort_by'      => 'date_updated',
-        '_sort_order'   => 'DESC',
-    );
-
-    /**
      * @var bool
      */
     protected $persistFilters = true;


### PR DESCRIPTION
This should not be placed here as the Page object does not have any properties and we don't know yet how to sort, leave it to Sonata's default.