### PR TITLE
Fix for the content item type view var to be constructed from the FQCN again

### DIFF
--- a/src/Zicht/Bundle/PageBundle/Type/ContentItemTypeType.php
+++ b/src/Zicht/Bundle/PageBundle/Type/ContentItemTypeType.php
@@ -119,7 +119,7 @@ class ContentItemTypeType extends AbstractType
                     }
                 }
                 if ($isPersistedEntity && $typeAdmin = $this->sonata->getAdminByClass(get_class($subject))) {
-                    $view->vars['type'] = Str::humanize(Str::classname($subject->getConvertToType()));
+                    $view->vars['type'] = Str::humanize($subject->getType());
                     $childAdmin = $this->sonata->getAdminByAdminCode($parentAdmin->getCode() . '|' . $typeAdmin->getCode());
                     $childAdmin->setRequest($genericAdmin->getRequest());
 


### PR DESCRIPTION
This was already done for version 3.0.0 in commit 6578194 but was lost in merging release 2.x into release 3.x in merge commit aef957f after the 2.7.2 hotfix was done.

Resolves #39
