### PR TITLE
Remove deprecations in our AbstractController

### DIFF
--- a/src/Zicht/Bundle/PageBundle/Manager/Doctrine/Subscriber.php
+++ b/src/Zicht/Bundle/PageBundle/Manager/Doctrine/Subscriber.php
@@ -9,6 +9,7 @@ use Doctrine\Common\EventSubscriber;
 use Doctrine\ORM\Event\LoadClassMetadataEventArgs;
 use Doctrine\ORM\Events;
 use Symfony\Component\DependencyInjection\ContainerInterface;
+use Zicht\Bundle\PageBundle\Manager\PageManager;
 
 /**
  * Subscriber for loading the class metadata for content items and pages. Delegates to
@@ -17,31 +18,24 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 class Subscriber implements EventSubscriber
 {
     /**
-     * @var ContainerInterface
+     * @var PageManager
      */
-    private $container;
+    private $pageManager;
 
-    /**
-     * Construct the subscriber.
-     *
-     * @param \Symfony\Component\DependencyInjection\ContainerInterface $container
-     */
-    public function __construct(ContainerInterface $container)
+    public function __construct(PageManager $pageManager)
     {
-        $this->container = $container;
+        $this->pageManager = $pageManager;
     }
-
 
     /**
      * Returns the page manager service.
      *
-     * @return \Zicht\Bundle\PageBundle\Manager\PageManager
+     * @return PageManager
      */
     public function getManager()
     {
-        return $this->container->get('zicht_page.page_manager');
+        return $this->pageManager;
     }
-
 
     /**
      * Delegates to PageManager::decorateClassMetaData to load the class meta data
@@ -53,7 +47,6 @@ class Subscriber implements EventSubscriber
     {
         $this->getManager()->decorateClassMetaData($args->getClassMetadata());
     }
-
 
     /**
      * @{inheritDoc}

--- a/src/Zicht/Bundle/PageBundle/Resources/config/services.xml
+++ b/src/Zicht/Bundle/PageBundle/Resources/config/services.xml
@@ -23,7 +23,7 @@
             <tag name="zicht_url.url_provider"/>
         </service>
         <service id="zicht_page.page_manager_subscriber" class="%zicht_page.page_manager_subscriber.class%">
-            <argument type="service" id="service_container"/>
+            <argument type="service" id="zicht_page.page_manager"/>
             <tag name="doctrine.event_subscriber"/>
         </service>
         <service id="zicht_page.form.type.zicht_content_item_type_type" class="%zicht_page.form.type.zicht_content_item_type_type.class%">
@@ -52,7 +52,7 @@
             <argument type="service" id="event_dispatcher"/>
             <tag name="zicht_admin.event_propagation" event="zicht_page.view"/>
         </service>
-        <service id="zicht_page.page_manager" class="%zicht_page.page_manager.class%">
+        <service id="zicht_page.page_manager" class="%zicht_page.page_manager.class%" public="true">
             <argument type="service" id="doctrine"/>
             <argument type="service" id="event_dispatcher"/>
             <argument/>
@@ -68,7 +68,7 @@
             <tag name="validator.constraint_validator" alias="zicht_page.validator.content_item_matrix_validator" />
             <argument type="service" id="translator"/>
         </service>
-        <service id="zicht_page.controller.view_validator" class="%zicht_page.controller.view_validator.class%">
+        <service id="zicht_page.controller.view_validator" class="%zicht_page.controller.view_validator.class%" public="true">
             <argument type="service" id="security.authorization_checker" on-invalid="null"/>
         </service>
     </services>


### PR DESCRIPTION
```
User Deprecated: The "zicht_page.page_manager" service is private, 
getting it from the container is deprecated since Symfony 3.2 and will fail in 4.0. 
You should either make the service public, 
or stop using the container directly and use dependency injection instead.

User Deprecated: The "zicht_page.controller.view_validator" service is private, 
getting it from the container is deprecated since Symfony 3.2 and will fail in 4.0. 
You should either make the service public, 
or stop using the container directly and use dependency injection instead.
```
