### PR TITLE
Fix url-bundle required version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "php": "^5.6 || ^7",
         "zicht/util": "^1.7",
         "zicht/admin-bundle": "^3.5 || ^4",
-        "zicht/url-bundle": "^2.4",
+        "zicht/url-bundle": "^2.4 || ^3",
         "zicht/menu-bundle": "^2.2"
     },
     "require-dev": {


### PR DESCRIPTION
Page bundle v3 is compatible with PHP 5.6 and 7, but it requires zicht/url-bundle `^2.4` which is only compatible with PHP 5.6. So changed the requirement to `^2.4 || ^3`