### PR TITLE
On duplicate set isPublic false

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added|Changed|Deprecated|Removed|Fixed|Security
 Nothing so far
 
+## 6.1.0 - 2020-10-29
+### Added
+- Added the AdminObjectDuplicateListener to listen to an event, dispatched in the admin-bundle, to set isPublic to false on duplicate.
+
 ## 6.0.3 - 2020-09-08
 ### Fixed
 - Forward merge of v5.0.16: Trigger 403 response instead of redirecting to the login page

--- a/composer.json
+++ b/composer.json
@@ -7,11 +7,11 @@
         "php": "^7.1",
         "sonata-project/admin-bundle": "^3.1",
         "symfony/console": "^4.4",
-        "zicht/util": "^1.7",
-        "zicht/admin-bundle": "^6",
+        "zicht/admin-bundle": "^6.1",
         "zicht/framework-extra-bundle": "^9",
+        "zicht/menu-bundle": "^4",
         "zicht/url-bundle": "^5",
-        "zicht/menu-bundle": "^4"
+        "zicht/util": "^1.7"
     },
     "require-dev": {
         "phpunit/phpunit": "^7"

--- a/src/Event/AdminObjectDuplicateListener.php
+++ b/src/Event/AdminObjectDuplicateListener.php
@@ -1,0 +1,28 @@
+<?php declare(strict_types=1);
+/**
+ * @copyright Zicht Online <https://zicht.nl>
+ */
+
+namespace Zicht\Bundle\PageBundle\Event;
+
+use Zicht\Bundle\AdminBundle\Event\ObjectDuplicateEvent;
+use Zicht\Bundle\PageBundle\Entity\Page;
+
+/**
+ * This listener listens to the event 'zicht_admin.object_duplicate' dispatched in the CRUDController in the admin-bundle
+ */
+class AdminObjectDuplicateListener
+{
+    public function onZichtadminObjectduplicate(ObjectDuplicateEvent $event): void
+    {
+        if (!($event->getOldObject() instanceof Page)){
+            return;
+        }
+        $newPage = $event->getNewObject();
+        $oldPage = $event->getOldObject();
+        
+        if (method_exists($newPage, 'setIsPublic')){
+            $newPage->setIsPublic(false);
+        }
+    }
+}

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -85,5 +85,9 @@
             <argument type="service" id="zicht_url.provider"/>
         </service>
 
+        <service id="Zicht\Bundle\PageBundle\Event\AdminObjectDuplicateListener">
+            <tag name="kernel.event_listener" event="zicht_admin.object_duplicate"/>
+        </service>
+
     </services>
 </container>


### PR DESCRIPTION
In progress..

This code goes together with https://github.com/zicht/zestor.nl/pull/155 and https://github.com/zicht/admin-bundle/pull/51. The purpose of this all is to be able to copy a page, to fill the copied page with new content end then to override the content of the old page with the new content. This way people can already prepare changes to a page and view these changes, without putting the changes live immediately .
