### PR TITLE
[ZES-137] fix the problem where the order of content-items is not wor…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added|Changed|Deprecated|Removed|Fixed|Security
 Nothing so far
 
+## 6.1.1 - 2020-11-05
+### Fixed
+- Resolve the problem where the current weight is not set to the converted content-item
+
 ## 6.1.0 - 2020-10-29
 ### Added
 - Added the AdminObjectDuplicateListener to listen to an event, dispatched in the admin-bundle, to set isPublic to false on duplicate.


### PR DESCRIPTION
Bij het toevoegen van een content-item klopt het gewicht niet die het content-item krijg.

![Peek 2020-11-05 11-44](https://user-images.githubusercontent.com/7580635/98231204-65c82580-1f5c-11eb-8ab8-6001a3c8e541.gif)

Maar wanneer je een content-item toevoegd die van het zelfde type is als de laatste content-item in de lijst dan krijgt die wel de juiste gewicht.

![Peek 2020-11-05 11-45](https://user-images.githubusercontent.com/7580635/98231417-ad4eb180-1f5c-11eb-9a77-5614c437d6d2.gif)


Wanneer je een nieuwe content-item toevoegt, dan wordt er al een object aangemaakt. Als je dan de content-item type verandert, dan wordt ie geconverteerd. Alleen worden de waardes niet doorgegevens tijdens het converteren. 

![Screenshot from 2020-11-04 16-56-53](https://user-images.githubusercontent.com/7580635/98231986-66ad8700-1f5d-11eb-9c4c-8626a0c4e6cd.png)


In deze method worden de properties benaderd van de entity en doorgegeven aan de nieuwe content-item.

```
public static function convert(ContentItemInterface $from, ContentItemInterface $to)
    {
        $reflectionFrom = new \ReflectionClass($from);
        $reflectionTo = new \ReflectionClass($to);

        foreach ($reflectionFrom->getProperties() as $property) {
            $property->setAccessible(true);
            $method = 'set' . ucfirst($property->getName());

            if ($reflectionTo->hasMethod($method)) {
                $to->$method($property->getValue($from));

            }
        }

        return $to;
    }
```

Alleen kijkt deze functie `$reflectionFrom->getProperties() ` alleen naar de methods binnen de entity en niet naar de parent classes. Omdat onze content-items de content-item class extenden wordt er niet gekeken naar de weight property.

Als je bijvoorbeeld binnen het project de weight property op **public** zet werkt de convert ook.

![Screenshot from 2020-11-05 12-04-24](https://user-images.githubusercontent.com/7580635/98233277-17685600-1f5f-11eb-82cb-cdbe7598b526.png)

Wanneer de weight property **private** is:

![Screenshot from 2020-11-05 12-05-32](https://user-images.githubusercontent.com/7580635/98233375-4088e680-1f5f-11eb-88de-e1dc6cec4300.png)

Conclusie door naar de parent class te kijken worden alle properties benaderd waardoor de convert goed gaat. Zoals hiervoor bij oudere projecten het goed gaat.

**`dump($property)`** in KIDV waar de content-items werken zoals we verwachten 
![Screenshot from 2020-11-05 09-56-34](https://user-images.githubusercontent.com/7580635/98233531-7b8b1a00-1f5f-11eb-8c7f-bbf27b6d5485.png)

**`dump($property)`** in zestor met de wijzigingen binnen deze pull request
![Screenshot from 2020-11-05 10-34-51](https://user-images.githubusercontent.com/7580635/98233533-7cbc4700-1f5f-11eb-883c-f973b746bd85.png)


