### PR TITLE
Content items fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,20 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added|Changed|Deprecated|Removed|Fixed|Security
 Nothing so far
 
+## 6.2.0 - 2021-05-20
+### Added
+- Added `region` option to ContentItemTypeType to show types for a specific region only
+- Introduced `HasContentItemInterface` interface to indicate an item which has a (child)
+  Content Item (e.g. for Global Content Items used in projects)
+### Fixed
+- ContentItemTypeType choice keys and values (flipped since Sf 3)
+- Fixed types in ContentItemContainer, ContentItemMatrix
+- Use `choice.content_item_region.X` translates for content item region choices
+- Skip base class in DiscriminatorMapType choices + optimized code
+- Fixed content item edit link: made it into button and got the wrench icon back again
+### Changed
+- Use early returns in code to optimize the code and its readability
+
 ## 6.1.3 - 2021-03-01
 ### Added
 - Added support for Psalm static analysis

--- a/src/Admin/ContentItemAdmin.php
+++ b/src/Admin/ContentItemAdmin.php
@@ -27,20 +27,22 @@ class ContentItemAdmin extends AbstractAdmin
      */
     protected function configureFormFields(FormMapper $form)
     {
-        if (!$this->isChild()) {
+        $parentFieldDescription = $this->getParentFieldDescription();
+        if (!$this->isChild() || !$parentFieldDescription) {
             $form->add('page');
-        } else {
-            $page = $this->getParentFieldDescription()->getAdmin()->getSubject();
-
-            // This fixes a weird bug where the router does not get the correct parameters for the containing page.
-            $this->getParentFieldDescription()->setOption('link_parameters', array('id' => $page->getId()));
-
-            $form
-                ->add('weight')
-                ->add('internalName', TextType::class, array('disabled' => true, 'required' => false, 'attr' => ['read_only' => true]))
-                ->add('content_item_region', ContentItemRegionType::class, array('container' => $page))
-                ->add('content_item_type', ContentItemTypeType::class, array('container' => $page));
+            return;
         }
+
+        $page = $parentFieldDescription->getAdmin()->getSubject();
+
+        // This fixes a weird bug where the router does not get the correct parameters for the containing page.
+        $parentFieldDescription->setOption('link_parameters', ['id' => $page->getId()]);
+
+        $form
+            ->add('weight')
+            ->add('internalName', TextType::class, ['disabled' => true, 'required' => false, 'attr' => ['read_only' => true]])
+            ->add('content_item_region', ContentItemRegionType::class, ['container' => $page])
+            ->add('content_item_type', ContentItemTypeType::class, ['container' => $page, 'region' => $parentFieldDescription->getOption('region')]);
     }
 
     /**

--- a/src/Model/ContentItemContainer.php
+++ b/src/Model/ContentItemContainer.php
@@ -14,15 +14,15 @@ interface ContentItemContainer
     /**
      * Returns the content item matrix for the item.
      *
-     * @return ContentItemMatrix
+     * @return ContentItemMatrix|null
      */
     public function getContentItemMatrix();
 
     /**
      * Returns a list of ContentItems
      *
-     * @param null $region
-     * @return mixed
+     * @param string|null $region
+     * @return iterable<array-key, ContentItemInterface>
      */
     public function getContentItems($region = null);
 
@@ -30,7 +30,6 @@ interface ContentItemContainer
      * Adds a ContentItem
      *
      * @param ContentItemInterface $contentItem
-     * @return mixed
      */
     public function addContentItem(ContentItemInterface $contentItem);
 
@@ -38,7 +37,6 @@ interface ContentItemContainer
      * Remove a ContentItem
      *
      * @param ContentItemInterface $contentItem
-     * @return mixed
      */
     public function removeContentItem(ContentItemInterface $contentItem);
 }

--- a/src/Model/ContentItemMatrix.php
+++ b/src/Model/ContentItemMatrix.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * @copyright Zicht Online <http://zicht.nl>
+ * @copyright Zicht Online <https://zicht.nl>
  */
 
 namespace Zicht\Bundle\PageBundle\Model;
@@ -33,7 +33,7 @@ final class ContentItemMatrix
     /**
      * Contains the matrix
      *
-     * @var array
+     * @var array<string, class-string<ContentItemInterface>[]>
      */
     private $matrix;
 
@@ -49,7 +49,7 @@ final class ContentItemMatrix
     /**
      * Provides fluent interface for building the matrix.
      *
-     * @return ContentItemMatrix
+     * @return self
      */
     public static function create()
     {
@@ -61,8 +61,7 @@ final class ContentItemMatrix
      *
      * @param string $region
      * @param bool $reset
-     *
-     * @return ContentItemMatrix
+     * @return $this
      */
     public function region($region, $reset = false)
     {
@@ -78,7 +77,6 @@ final class ContentItemMatrix
      * Remove a region
      *
      * @param string $region
-     *
      * @return $this
      */
     public function removeRegion($region)
@@ -93,9 +91,8 @@ final class ContentItemMatrix
     /**
      * Remove a type from a region
      *
-     * @param string $type
+     * @param class-string<ContentItemInterface> $type
      * @param string $region
-     *
      * @return $this
      */
     public function removeTypeFromRegion($type, $region)
@@ -121,9 +118,8 @@ final class ContentItemMatrix
     /**
      * Adds the type to the currently selected region.
      *
-     * @param string $className
-     *
-     * @return ContentItemMatrix
+     * @param class-string<ContentItemInterface> $className
+     * @return $this
      */
     public function type($className)
     {
@@ -144,9 +140,8 @@ final class ContentItemMatrix
      * Returns the available types for a specified region.
      * If not specified, returns all types configured.
      *
-     * @param string $region
-     *
-     * @return array
+     * @param string|null $region
+     * @return class-string<ContentItemInterface>[]
      */
     public function getTypes($region = null)
     {
@@ -166,9 +161,8 @@ final class ContentItemMatrix
      * Returns the available regions for a specified type.
      * If not specified, all regions are returned.
      *
-     * @param null $type
-     *
-     * @return array
+     * @param class-string<ContentItemInterface>|null $type
+     * @return string[]
      */
     public function getRegions($type = null)
     {
@@ -187,7 +181,7 @@ final class ContentItemMatrix
     }
 
     /**
-     * @return array
+     * @return array<string, class-string<ContentItemInterface>[]>
      */
     public function getMatrix()
     {

--- a/src/Model/HasContentItemInterface.php
+++ b/src/Model/HasContentItemInterface.php
@@ -1,0 +1,14 @@
+<?php declare(strict_types=1);
+/**
+ * @copyright Zicht Online <https://zicht.nl>
+ */
+
+namespace Zicht\Bundle\PageBundle\Model;
+
+/**
+ * Interface to indicate that an object (= parent) has a (child) ContentIntemInterface
+ */
+interface HasContentItemInterface
+{
+    public function getContentItem(): ?ContentItemInterface;
+}

--- a/src/Resources/views/form_theme.html.twig
+++ b/src/Resources/views/form_theme.html.twig
@@ -2,7 +2,7 @@
     {% if type %}
         <input type="hidden" name="{{ name }}" value="{{ value }}">
         {% if edit_url %}
-            <a class="edit_link" href="{{ edit_url }}"> {{ ('content_item.type.' ~ (type|replace({' ': '_'})|lower))|trans({}, 'admin') }} <a class="edit_link" href="{{ edit_url }}"><i class="icon-wrench"></i></a>
+            <a class="btn" href="{{ edit_url }}"> {{ ('content_item.type.' ~ (type|replace({' ': '_'})|lower))|trans({}, 'admin') }}&nbsp; <i class="fa fa-wrench" aria-hidden="true"></i>&nbsp;</a>
         {% else %}
             {{ ('content_item.type.' ~ (type|replace({' ': '_'})|lower))|trans({}, 'admin') }}
         {% endif %}
@@ -18,15 +18,14 @@
         <script type="text/javascript">
             window.attachMatrixHandler = window.attachMatrixHandler || function(matrix, field) {
                 var regionSelect = $(field),
-                        regionBlockSelect = regionSelect.parent().next().find('select')
-                        ;
+                    regionBlockSelect = regionSelect.parent().next().find('select');
 
                 function updateValues(region) {
                     var values = matrix[region];
                     regionBlockSelect.empty();
                     for (var value in values) {
                         regionBlockSelect.append(
-                                $('<option />').val(value).text(values[value])
+                            $('<option />').val(value).text(values[value])
                         );
                     }
                 }

--- a/src/Validator/Constraints/ContentItemMatrix.php
+++ b/src/Validator/Constraints/ContentItemMatrix.php
@@ -1,22 +1,16 @@
 <?php
 /**
- * @author Gerard van Helden <gerard@zicht.nl>
- * @copyright Zicht Online <http://zicht.nl>
+ * @copyright Zicht Online <https://zicht.nl>
  */
+
 namespace Zicht\Bundle\PageBundle\Validator\Constraints;
 
 use Symfony\Component\Validator\Constraint;
 
-/**
- * Class ContentItemMatrix
- *
- * @package Zicht\Bundle\PageBundle\Validator\Constraints
- */
 class ContentItemMatrix extends Constraint
 {
-
     /**
-     * @return string
+     * {@inheritDoc}
      */
     public function getTargets()
     {
@@ -24,9 +18,7 @@ class ContentItemMatrix extends Constraint
     }
 
     /**
-     * Returns service name
-     *
-     * @return string
+     * {@inheritDoc}
      */
     public function validatedBy()
     {


### PR DESCRIPTION
Added:
- Added `region` option to ContentItemTypeType to show types for a specific region only
- Introduced `HasContentItemInterface` interface to indicate an item which has a (child)
  Content Item (e.g. for Global Content Items used in projects)

Fixed:
- ContentItemTypeType choice keys and values (flipped since Sf 3)
- Fixed types in ContentItemContainer, ContentItemMatrix
- Use `choice.content_item_region.X` translates for content item region choices
- Skip base class in DiscriminatorMapType choices + optimized code
- Fixed content item edit link: made it into button and got the wrench icon back again

Changed:
- Use early returns in code to optimize the code and its readability