### PR TITLE
Change return-type for getController and add extra check in viewAction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added|Changed|Deprecated|Removed|Fixed|Security
 Nothing so far
 
+## 6.1.4 - 2021-06-23
+### Added
+- Added check in viewAction for the case an OverviewPage doesn't need a Controller
+### Fixed
+- Set correct return type for getController() in ControllerPageInterface.php
+
 ## 6.1.3 - 2021-03-01
 ### Added
 - Added support for Psalm static analysis

--- a/src/Controller/PageController.php
+++ b/src/Controller/PageController.php
@@ -87,7 +87,7 @@ class PageController extends AbstractController
             }
         }
 
-        if ($page instanceof ControllerPageInterface) {
+        if ($page instanceof ControllerPageInterface && $page->getController() !== null) {
             return $this->forward(
                 $page->getController(),
                 (array)$page->getControllerParameters()

--- a/src/Entity/ControllerPageInterface.php
+++ b/src/Entity/ControllerPageInterface.php
@@ -14,7 +14,7 @@ interface ControllerPageInterface
     /**
      * Returns a controller reference (string) which is responsible for rendering the page.
      *
-     * @return mixed
+     * @return string|null
      */
     public function getController();
 


### PR DESCRIPTION
In PGO there's a case where an OverviewPage doesn't need a Controller (`$page->getController()` is null). For that, this addition in the code is very helpfull.