### PR TITLE
Static call for ScheduledContentRepositoryTrait::getPublishedCriteria()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 ### Fixed
 - Fixed `TokenInterface->getRoles()` deprecation using `TokenInterface->getRoleNames()` instead
+### Changed
+- Deprecated non-static `generatePublisedWhereClausesCriteria()` and added static `getPublishedCriteria()` in `ScheduledContentRepositoryTrait`
 ### Added|Changed|Deprecated|Removed|Fixed|Security
 Nothing else so far
 

--- a/src/Repository/ScheduledContentRepositoryTrait.php
+++ b/src/Repository/ScheduledContentRepositoryTrait.php
@@ -7,37 +7,40 @@ use Doctrine\Common\Collections\Criteria;
 trait ScheduledContentRepositoryTrait
 {
     /**
-     * Usage: $queryBuilder->addCriteria()
+     * Usage: $queryBuilder->addCriteria(static::getPublishedCriteria())
      */
-    private function generatePublisedWhereClausesCriteria(string $alias = 'p', \DateTimeInterface $refDate = null): Criteria
+    protected static function getPublishedCriteria(?string $alias = 'p', \DateTimeInterface $refDate = null): Criteria
     {
         if (null === $refDate) {
             $refDate = new \DateTimeImmutable('now');
         }
+
+        $prefix = $alias !== null && $alias !== '' ? $alias . '.' : '';
+
         $expr = Criteria::expr();
 
         return Criteria::create()
             ->andWhere(
-                $expr->eq($alias . '.isPublic', true)
+                $expr->eq($prefix . 'isPublic', true)
             )->andWhere(
-                $expr->orX(
-                    $expr->andX(
-                        $expr->isNull($alias . '.dateScheduledFrom'),
-                        $expr->isNull($alias . '.dateScheduledTill'),
+                $expr->andX(
+                    $expr->orX(
+                        $expr->isNull($prefix . 'dateScheduledFrom'),
+                        $expr->lte($prefix . 'dateScheduledFrom', $refDate)
                     ),
-                    $expr->andX(
-                        $expr->lte($alias . '.dateScheduledFrom', $refDate),
-                        $expr->isNull($alias . '.dateScheduledTill')
-                    ),
-                    $expr->andX(
-                        $expr->isNull($alias . '.dateScheduledFrom'),
-                        $expr->gte($alias . '.dateScheduledTill', $refDate)
-                    ),
-                    $expr->andX(
-                        $expr->lte($alias . '.dateScheduledFrom', $refDate),
-                        $expr->gte($alias . '.dateScheduledTill', $refDate)
+                    $expr->orX(
+                        $expr->isNull($prefix . 'dateScheduledTill'),
+                        $expr->gte($prefix . 'dateScheduledTill', $refDate)
                     )
                 )
             );
+    }
+
+    /**
+     * @deprecated Use static call instead: static::getPublishedCriteria()
+     */
+    private function generatePublisedWhereClausesCriteria(string $alias = 'p', \DateTimeInterface $refDate = null): Criteria
+    {
+        return static::getPublishedCriteria($alias, $refDate);
     }
 }


### PR DESCRIPTION
- Add a static method with protected visibility (and correct spelling)
- Deprecated the `generatePublisedWhereClausesCriteria()` method
- Allowed alias to be null for use outside database query context (e.g. collection matching or filtering)
- Reduced the criteria statements to two possibilities instead of all four possibilities written out