### PR TITLE
Allow partial admin definitions and merge them into the auto generated ones

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added|Changed|Deprecated|Removed|Fixed|Security
 Nothing so far
 
+## 6.2.0 - 2021-09-15
+### Added
+- Possibility to add a (partial) Page or Content Item admin definition in your
+  project. Those values will be merged into the auto-generated service definition.
+
 ## 6.1.5 - 2021-07-27
 ### Fixed
 - Fixed `TokenInterface->getRoles()` deprecation using `TokenInterface->getRoleNames()` instead

--- a/src/DependencyInjection/CompilerPass/GenerateAdminServicesCompilerPass.php
+++ b/src/DependencyInjection/CompilerPass/GenerateAdminServicesCompilerPass.php
@@ -75,6 +75,29 @@ class GenerateAdminServicesCompilerPass implements CompilerPassInterface
                 $adminService->replaceArgument(0, $id);
                 $adminService->replaceArgument(1, $entityClassName);
 
+                // If there's a (partial) definition for this Page or ContentItem Admin already, then take
+                // the relevant values and place them onto (or merge them into) our admin service.
+                if ($container->hasDefinition($id)) {
+                    $mergeWithAdminService = $container->getDefinition($id);
+                    if ($mergeWithAdminService->getClass() !== null) {
+                        $adminService->setClass($mergeWithAdminService->getClass());
+                    }
+                    if (count($mergeWithAdminService->getMethodCalls()) > 0) {
+                        $adminService->setMethodCalls(array_merge($adminService->getMethodCalls(), $mergeWithAdminService->getMethodCalls()));
+                    }
+                    if (count($mergeWithAdminService->getProperties()) > 0) {
+                        $adminService->setProperties(array_merge($adminService->getProperties(), $mergeWithAdminService->getProperties()));
+                    }
+                    if (count($mergeWithAdminService->getTags()) > 0) {
+                        $adminService->setTags(array_merge($adminService->getTags(), $mergeWithAdminService->getTags()));
+                    }
+                    if (count($mergeWithAdminService->getArguments()) > 0) {
+                        $mergedArguments = $mergeWithAdminService->getArguments() + $adminService->getArguments();
+                        ksort($mergedArguments, SORT_NATURAL);
+                        $adminService->setArguments($mergedArguments);
+                    }
+                }
+
                 $container->setDefinition($id, $adminService);
 
                 $serviceDefinitions[$type][] = $id;


### PR DESCRIPTION
This is a feature that I've always wanted to have (ever since I bumped into this the first time, probably some 3 years ago). In my project I can now add/change the following in the admin service definitions file:

```diff
diff --git a/config/services/admin.yaml b/config/services/admin.yaml
index fcf13c4..e65e77f 100644
--- a/config/services/admin.yaml
+++ b/config/services/admin.yaml
@@ -49,6 +49,11 @@ services:
         calls:
             - [setTranslationDomain, ['admin']]
 
-# BE AWARE! DO NOT ADD PAGE OR CONTENTITEM ADMINS HERE!
-# The admin configuration will be generated/handled by the ZichtPageBundle.
-# If you add the page related admins here, hell will break loose ^^
+# BE AWARE! YOU CAN ADD (PARTIAL) PAGE AND CONTENT ITEM ADMIN DEFINITIONS BELOW
+# The admin configuration will be generated/handled by the ZichtPageBundle and below definitions will be merged into those.
+# You can add (partial) definitions here and the following elements will be merged into the auto generated definitions:
+# - class, calls, properties, tags and arguments
+
+    app.admin.page.foopageadmin:
+        calls:
+            - [addChild, ['@app.admin.page.barpageadmin']]
```

You can easily add/modify things of the Page Bundle admin definitions (Page admins and Content Item admins) without having to create a Compiler Pass which modifies the auto-generated definitions afterwards.