### PR TITLE
Remove bundle from bundle name in template path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added|Changed|Deprecated|Removed|Fixed|Security
 Nothing so far
 
+## 6.2.4 - 2022-04-11
+### Fixed
+- Template path for `@ZichtWebsiteBundle/Page/template.twig.html` should be `@ZichtWebsite/Page/template.twig.html` without the `Bundle` suffix
+
 ## 6.2.3 - 2022-04-05
 ### Added
 - Added ContentItemTypeType admin retrieval check

--- a/src/Manager/PageManager.php
+++ b/src/Manager/PageManager.php
@@ -90,12 +90,12 @@ class PageManager
     public function getTemplate($page)
     {
         $className = ClassUtils::getRealClass(get_class($page));
-        if (strpos($className, 'App') === 0) {
+        if (strpos($className, 'App\\') === 0) {
             return sprintf('page/%s.html.twig', $page->getTemplateName());
         }
 
         // Not in App namespace, so determine the page bundle name.
-        $bundle = $this->getBundleName($className);
+        $bundle = $this->getTemplateBundleName($className);
         return sprintf('@%s/Page/%s.html.twig', $bundle, $page->getTemplateName());
     }
 
@@ -127,7 +127,22 @@ class PageManager
 
             throw new \RuntimeException("Could not determine bundle name for " . $className);
         }
+
         $bundle = $vendor . $bundleName;
+
+        return $bundle;
+    }
+
+    /**
+     * @param class-string $className
+     */
+    protected function getTemplateBundleName(string $className): string
+    {
+        $bundle = $this->getBundleName($className);
+
+        if (strlen($bundle) > 6 && substr($bundle, -6) === 'Bundle') {
+            $bundle = substr($bundle, 0, -6);
+        }
 
         return $bundle;
     }

--- a/tests/Manager/PageManagerTest.php
+++ b/tests/Manager/PageManagerTest.php
@@ -18,27 +18,24 @@ namespace ZichtTest\Bundle\SomeBundle\Entity\ContentItem {
     }
 }
 
-namespace My\PageBundle\Entity {
-
+namespace App\Entity {
     use ZichtTest\Bundle\PageBundle\Assets\PageAdapter;
-
     class FooBarPage extends PageAdapter {
         public function getTitle()
         {
             return '';
         }
 
-        /**
-         * A page must always have an id
-         *
-         * @return mixed
-         */
         public function getId()
         {
             // TODO: Implement getId() method.
         }
 
     }
+}
+namespace My\PageBundle\Entity {
+    use App\Entity\FooBarPage as AppFooBarPage;
+    class FooBarPage extends AppFooBarPage {}
 }
 
 namespace ZichtTest\Bundle\PageBundle\Manager {
@@ -69,10 +66,16 @@ namespace ZichtTest\Bundle\PageBundle\Manager {
             );
         }
 
+        function testGetTemplateWillReturnAppTemplate() {
+            $this->assertEquals(
+                'page/foo-bar.html.twig',
+                $this->pageManager->getTemplate(new \App\Entity\FooBarPage())
+            );
+        }
 
         function testGetTemplateWillReturnBundleTemplate() {
             $this->assertEquals(
-                '@MyPageBundle/Page/foo-bar.html.twig',
+                '@MyPage/Page/foo-bar.html.twig',
                 $this->pageManager->getTemplate(new \My\PageBundle\Entity\FooBarPage())
             );
         }


### PR DESCRIPTION
Het template path `@ZichtWebsiteBundle/Page/template.twig.html` moet zijn `@ZichtWebsite/Page/template.twig.html` zonder `Bundle`.

In nieuwe projecten gebruiken we alleen Page entities in de namespace `App\Entity\Page` en resolved that naar een template in de root dir `templates/` in het project (`templates/page/template.twig.html`) en daar kom je deze bug niet tegen. Alleen bij het upgraden van projecten van Sf 3 naar Sf 4 met behoud van de "site bundle(s)", kom je deze bug tegen. Sf 4 kan de `@ZichtWebsiteBundle` alias niet resolven (omdat het `@ZichtWesbite` moet zijn). Zie bijv. de RAR upgrade waar er voor alle bundles hardcoded aliases aan zijn gemaakt (i.p.v. de juiste gebruiken):

https://github.com/zicht/regionaalarchiefrivierenland.nl/blob/release/6.0.x/config/packages/twig.yaml 

```yaml
    paths:
        '%kernel.project_dir%/vendor/sonata-project/admin-bundle/src/Resources/views': SonataAdminBundle
        '%kernel.project_dir%/vendor/sonata-project/form-extensions/src/Bridge/Symfony/Resources/views': SonataFormBundle
        '%kernel.project_dir%/vendor/zicht/filemanager-bundle/src/Resources/views': ZichtFileManagerBundle
        '%kernel.project_dir%/vendor/zicht/framework-extra-bundle/src/Resources/views': ZichtFrameworkExtraBundle
        '%kernel.project_dir%/src/PopUpBundle/Resources/views': ZichtPopUpBundle
        '%kernel.project_dir%/src/RarDereeBundle/Resources/views': ZichtRarDereeBundle
        '%kernel.project_dir%/src/RarWebsiteBundle/Resources/views': ZichtRarWebsiteBundle
```
