### PR TITLE
[TIN-XXX] add the correct collection type

### DIFF
--- a/src/Zicht/Bundle/PageBundle/Admin/PageAdmin.php
+++ b/src/Zicht/Bundle/PageBundle/Admin/PageAdmin.php
@@ -10,7 +10,7 @@ use Sonata\AdminBundle\Datagrid\DatagridMapper;
 use Sonata\AdminBundle\Datagrid\ListMapper;
 use Sonata\AdminBundle\Form\FormMapper;
 use Sonata\AdminBundle\Show\ShowMapper;
-use Sonata\Form\Type\CollectionType as SonataCollectionType;
+use Sonata\CoreBundle\Form\Type\CollectionType;
 use Symfony\Component\Form\FormEvent;
 use Symfony\Component\Form\FormEvents;
 use Zicht\Bundle\AdminBundle\Util\AdminUtil;
@@ -161,7 +161,7 @@ class PageAdmin extends Admin
                     ->tab('admin.tab.content')
                     ->add(
                         'contentItems',
-                        SonataCollectionType::class,
+                        CollectionType::class,
                         array(
                             'btn_add' => 'content_item.add'
                         ),


### PR DESCRIPTION
Update the collection type to the correct one so i can add content-items again in Tinbergen after a CMS update


![Screenshot from 2022-09-06 10-14-01](https://user-images.githubusercontent.com/7580635/188582920-cd68e97b-aaea-432b-9bd2-e88079cc9c73.png)
