### PR TITLE
[TIN-XXX] add the correct collection type

### DIFF
--- a/src/Zicht/Bundle/PageBundle/Admin/PageAdmin.php
+++ b/src/Zicht/Bundle/PageBundle/Admin/PageAdmin.php
@@ -10,7 +10,7 @@ use Sonata\AdminBundle\Datagrid\DatagridMapper;
 use Sonata\AdminBundle\Datagrid\ListMapper;
 use Sonata\AdminBundle\Form\FormMapper;
 use Sonata\AdminBundle\Show\ShowMapper;
-use Sonata\Form\Type\CollectionType as SonataCollectionType;
+use Sonata\CoreBundle\Form\Type\CollectionType;
 use Symfony\Component\Form\FormEvent;
 use Symfony\Component\Form\FormEvents;
 use Zicht\Bundle\AdminBundle\Util\AdminUtil;
@@ -161,7 +161,7 @@ class PageAdmin extends Admin
                     ->tab('admin.tab.content')
                     ->add(
                         'contentItems',
-                        SonataCollectionType::class,
+                        CollectionType::class,
                         array(
                             'btn_add' => 'content_item.add'
                         ),


### PR DESCRIPTION
Replace the old collection type use statement to the newer so i can add content-items again in Tinbergen after a CMS update

![Screenshot from 2022-09-06 10-14-01](https://user-images.githubusercontent.com/7580635/188583318-fdf4ecdd-897c-482f-a211-7b9f65371dac.png)
