### PR TITLE
Create a deprecation path caused by upcoming Symfony 6 changes.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added|Changed|Deprecated|Removed|Fixed|Security
 Nothing so far
 
+## 8.2.0 - 2023-04-28
+### Added
+- `PageControllerTrait` for handy functionalities that were in the `PageController` before.
+### Deprecated
+- `\Zicht\Bundle\PageBundle\Controller\AbstractController`
+- Extending `\Zicht\Bundle\PageBundle\Controller\PageController`. This class is soft marked `@final` now through annotation.
+### Fixed
+- Some minor deprecation warnings.
+
 ## 8.1.0 - 2022-12-07
 ### Added
 - Forward compatability for `doctrine/dbal ^3`

--- a/src/Controller/AbstractController.php
+++ b/src/Controller/AbstractController.php
@@ -8,6 +8,9 @@ namespace Zicht\Bundle\PageBundle\Controller;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController as BaseAbstractController;
 use Zicht\Bundle\PageBundle\Manager\PageManager;
 
+/**
+ * @deprecated extend {@see \Symfony\Bundle\FrameworkBundle\Controller\AbstractController} directly.
+ */
 abstract class AbstractController extends BaseAbstractController
 {
     public static function getSubscribedServices(): array
@@ -15,8 +18,10 @@ abstract class AbstractController extends BaseAbstractController
         return array_merge(parent::getSubscribedServices(), ['zicht_page.page_manager' => PageManager::class]);
     }
 
+    /** @deprecated Use constructor injection in your controller to inject the PageManager instead. */
     public function getPageManager(): PageManager
     {
+        trigger_deprecation('zicht/page-bundle', '8.2', 'Method "%s()" is deprecated, use constructor injection in your controller to inject the "PageManager" instead.', __METHOD__);
         return $this->get('zicht_page.page_manager');
     }
 }

--- a/src/Controller/DebugPagesController.php
+++ b/src/Controller/DebugPagesController.php
@@ -7,30 +7,34 @@ namespace Zicht\Bundle\PageBundle\Controller;
 
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\EntityRepository;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
+use Zicht\Bundle\PageBundle\Manager\PageManager;
 use Zicht\Bundle\PageBundle\Model\ContentItemInterface;
 use Zicht\Bundle\PageBundle\Model\PageInterface;
 
-class DebugPagesController extends AbstractController
+final class DebugPagesController extends AbstractController
 {
     private EntityManagerInterface $entityManager;
 
-    public function __construct(EntityManagerInterface $entityManager)
+    private PageManager $pageManager;
+
+    public function __construct(EntityManagerInterface $entityManager, PageManager $pageManager)
     {
         $this->entityManager = $entityManager;
+        $this->pageManager = $pageManager;
     }
 
     public function showProjectPageTypeLinksAndInfo(Request $request): Response
     {
-        $pageManager = $this->getPageManager();
         /** @var EntityRepository $repository */
-        $repository = $pageManager->getBaseRepository();
+        $repository = $this->pageManager->getBaseRepository();
 
         $pagesInfo = [];
         $totalCount = 0;
         $locale = $request->getLocale();
-        foreach ($pageManager->getPageTypes() as $pageType) {
+        foreach ($this->pageManager->getPageTypes() as $pageType) {
             $qb = $repository->createQueryBuilder('p');
             $qb->where($qb->expr()->isInstanceOf('p', $pageType));
             if ($locale && $this->pageSupportsLanguage($pageType)) {

--- a/src/Controller/PageControllerTrait.php
+++ b/src/Controller/PageControllerTrait.php
@@ -1,0 +1,92 @@
+<?php declare(strict_types=1);
+
+namespace Zicht\Bundle\PageBundle\Controller;
+
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
+use Symfony\Component\Security\Core\Exception\AccessDeniedException;
+use Zicht\Bundle\PageBundle\Entity\ControllerPageInterface;
+use Zicht\Bundle\PageBundle\Manager\PageManager;
+use Zicht\Bundle\PageBundle\Model\PageInterface;
+use Zicht\Bundle\PageBundle\Model\ViewValidationInterface;
+
+trait PageControllerTrait
+{
+    public function getPageManager(): PageManager
+    {
+        if (!property_exists($this, 'pageManager')) {
+            throw new \RuntimeException(sprintf('$pageManager property does not exists on %s. You should inject the PageManager into your controller.', get_class($this)));
+        }
+        if (!($this->pageManager instanceof PageManager)) {
+            throw new \RuntimeException(sprintf('$pageManager property does not contain an instance of %s. You should inject the correct PageManager into your controller.', PageManager::class));
+        }
+
+        return $this->pageManager;
+    }
+
+    public function renderPage(PageInterface $page, array $vars = []): Response
+    {
+        if (!method_exists($this, 'render')) {
+            throw new \RuntimeException(sprintf('render() method does not exists on %s. Your controller should extend %s.', get_class($this), AbstractController::class));
+        }
+
+        return $this->render(
+            $this->getPageManager()->getTemplate($page),
+            $vars + [
+                'page' => $page,
+                'id' => $page->getId(),
+            ]
+        );
+    }
+
+    protected function getViewActionValidator(): ?ViewValidationInterface
+    {
+        if (!property_exists($this, 'pageViewValidation')) {
+            throw new \RuntimeException(sprintf('pageViewValidation property does not exists on %s. You should inject the ViewValidationInterface into your controller.', get_class($this)));
+        }
+
+        if ($this->pageViewValidation instanceof ViewValidationInterface) {
+            return $this->pageViewValidation;
+        }
+
+        return null;
+    }
+
+    private function isViewActionAllowed(PageInterface $page): void
+    {
+        if (null !== ($validator = $this->getViewActionValidator())) {
+            try {
+                $validator->validate($page);
+            } catch (AccessDeniedException $e) {
+                // AccessDeniedException will cause a redirect to the login page, so we're throwing
+                // an AccessDeniedHttpException instead to make Symfony return a 403 response
+                // (don't pass the previous exception, as this will again cause a redirect to the login page)
+                throw new AccessDeniedHttpException($e->getMessage());
+            }
+        }
+    }
+
+    private function shouldForwardControllerPage(PageInterface $page, Request $request): ?Response
+    {
+        if (!($page instanceof ControllerPageInterface) || $page->getController() === null) {
+            return null;
+        }
+
+        if (!method_exists($this, 'forward')) {
+            throw new \RuntimeException(sprintf('forward() method does not exists on %s. Your controller should extend %s.', get_class($this), AbstractController::class));
+        }
+
+        return $this->forward(
+            $page->getController(),
+            (array)$page->getControllerParameters()
+            + [
+                'parameters' => $request->query->all(),
+                '_locale' => $request->attributes->get('_locale'),
+                '_internal_url' => $request->attributes->get('_internal_url'),
+            ],
+            $request->query->all()
+        );
+    }
+}

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -10,7 +10,7 @@ use Symfony\Component\Config\Definition\ConfigurationInterface;
 
 class Configuration implements ConfigurationInterface
 {
-    public function getConfigTreeBuilder()
+    public function getConfigTreeBuilder(): TreeBuilder
     {
         $treeBuilder = new TreeBuilder('zicht_page');
         $rootNode = $treeBuilder->getRootNode();

--- a/src/Manager/Doctrine/Subscriber.php
+++ b/src/Manager/Doctrine/Subscriber.php
@@ -37,7 +37,7 @@ class Subscriber implements EventSubscriber
         $this->getManager()->decorateClassMetaData($args->getClassMetadata());
     }
 
-    public function getSubscribedEvents()
+    public function getSubscribedEvents(): array
     {
         return [
             Events::loadClassMetadata,

--- a/src/Manager/PageManager.php
+++ b/src/Manager/PageManager.php
@@ -187,7 +187,7 @@ class PageManager
      * Find a page in the repository and trigger a view event.
      *
      * @param string $id
-     * @return mixed
+     * @return PageInterface
      * @throws NotFoundHttpException
      */
     public function findForView($id)
@@ -202,19 +202,22 @@ class PageManager
             ->getClassMetadata($this->pageClassName)->discriminatorMap;
 
         $class = $types[$type];
-        $repos = $this->doctrine->getRepository($class);
+        /** @var ObjectRepository<PageInterface> $repository */
+        $repository = $this->doctrine->getRepository($class);
 
-        if ($repos instanceof ViewablePageRepository) {
-            $ret = $repos->findForView($id);
+        if ($repository instanceof ViewablePageRepository) {
+            $page = $repository->findForView($id);
         } else {
-            $ret = $repos->find($id);
+            $page = $repository->find($id);
         }
 
-        if (!$ret) {
+        if (!$page) {
             throw new NotFoundHttpException();
         }
-        $this->setLoadedPage($ret);
-        return $ret;
+
+        $this->setLoadedPage($page);
+
+        return $page;
     }
 
     /**

--- a/src/Model/ContentItemInterface.php
+++ b/src/Model/ContentItemInterface.php
@@ -13,7 +13,7 @@ interface ContentItemInterface
     /**
      * Return the type name for the content item, usually it's class name.
      *
-     * @return mixed
+     * @return string
      */
     public function getType();
 

--- a/src/Repository/ScheduledContentRepositoryTrait.php
+++ b/src/Repository/ScheduledContentRepositoryTrait.php
@@ -41,6 +41,7 @@ trait ScheduledContentRepositoryTrait
      */
     private function generatePublisedWhereClausesCriteria(string $alias = 'p', \DateTimeInterface $refDate = null): Criteria
     {
+        trigger_deprecation('zicht/page-bundle', '6.1.5', 'Method "%s()" is deprecated. Use static call to "getPublishedCriteria()" instead.', __METHOD__);
         return static::getPublishedCriteria($alias, $refDate);
     }
 }

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -90,8 +90,15 @@
             <tag name="kernel.event_listener" event="zicht_admin.object_duplicate"/>
         </service>
 
+        <service id="Zicht\Bundle\PageBundle\Controller\PageController">
+            <argument type="service" id="zicht_page.page_manager"/>
+            <argument type="service" id="zicht_url.provider"/>
+            <argument type="service" id="zicht_page.controller.view_validator"/>
+        </service>
+
         <service id="Zicht\Bundle\PageBundle\Controller\DebugPagesController">
             <argument type="service" id="doctrine.orm.entity_manager"/>
+            <argument type="service" id="zicht_page.page_manager"/>
         </service>
 
         <prototype namespace="Zicht\Bundle\PageBundle\Controller\" resource="../../Controller/" autowire="true" public="true">

--- a/tests/Controller/PageControllerTest.php
+++ b/tests/Controller/PageControllerTest.php
@@ -11,6 +11,7 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\Security\Core\Exception\AccessDeniedException;
 use Zicht\Bundle\PageBundle\Controller\PageController;
+use Zicht\Bundle\UrlBundle\Url\Provider as UrlProvider;
 use ZichtTest\Bundle\PageBundle\Assets\PageAdapter;
 
 class Page extends PageAdapter
@@ -50,10 +51,11 @@ class PageControllerTest extends TestCase
 
     public function setUp(): void
     {
-        $this->controller = new PageController();
         $this->pm = $this->getMockBuilder('Zicht\Bundle\PageBundle\Manager\PageManager')->disableOriginalConstructor()->getMock();
-        $this->twig = $this->getMockBuilder('Twig\Environment')->disableOriginalConstructor()->getMock();
         $this->viewValidator = $this->getMockBuilder('Zicht\Bundle\PageBundle\Security\PageViewValidation')->getMock();
+        $urlProvider = $this->getMockBuilder(UrlProvider::class)->getMock();
+        $this->controller = new PageController($this->pm, $urlProvider, $this->viewValidator);
+        $this->twig = $this->getMockBuilder('Twig\Environment')->disableOriginalConstructor()->getMock();
 
         $this->viewValidator->method('validate');
 
@@ -112,8 +114,8 @@ class PageControllerTest extends TestCase
         $this->twig->expects($this->once())->method('render')->with(
             'foo.template',
             [
-            'page' => $page,
-            'id' => $id,
+                'page' => $page,
+                'id' => $id,
             ]
         );
 


### PR DESCRIPTION
The (services) container should not be used, making it necessary for any controller to inject the services by their own. This makes the Page Bundle AbstractController redundant.

Also included that the Page Bundle PageController will be final in the future as the only use for extending it, was for the handy functionalities that are now a bit more redundant because of the above.

Added the PageControllerTrait to still be able to use these "handy functionalities".

![Screenshot from 2023-04-28 20-58-28](https://user-images.githubusercontent.com/2794908/235230997-b8112d80-4501-4491-84ff-8fdff3fcdeaf.png)
